### PR TITLE
Feature/seller edit item

### DIFF
--- a/src/main/java/com/example/ecommerceproject/controller/SellerController.java
+++ b/src/main/java/com/example/ecommerceproject/controller/SellerController.java
@@ -1,6 +1,7 @@
 package com.example.ecommerceproject.controller;
 
 import com.example.ecommerceproject.constant.ItemSellStatus;
+import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
 import com.example.ecommerceproject.domain.dto.SellerItemResponseDto;
 import com.example.ecommerceproject.domain.dto.response.ApiResponse;
@@ -9,14 +10,12 @@ import com.example.ecommerceproject.domain.model.Item;
 import com.example.ecommerceproject.service.SellerService;
 import com.example.ecommerceproject.util.ValidUtil;
 import java.time.LocalDate;
-import java.util.stream.Stream;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -61,20 +60,36 @@ public class SellerController {
       @RequestParam(defaultValue = "0") Integer page,
       @RequestParam(defaultValue = "20") Integer size,
       @RequestParam(defaultValue = "id") String sort
-      ) {
+  ) {
 
     Pageable pageable = PageRequest.of(page, size, Sort.by(sort));
 
     // 입력하지 않은 값들에 대해 초기값 세팅
-    if(saleStatus == null) saleStatus = ItemSellStatus.SELL;
-    if(startDate == null) startDate = LocalDate.of(1970,1,1);
-    if(endDate == null) endDate = LocalDate.of(2023,12,31);
+    if (saleStatus == null) {
+      saleStatus = ItemSellStatus.SELL;
+    }
+    if (startDate == null) {
+      startDate = LocalDate.of(1970, 1, 1);
+    }
+    if (endDate == null) {
+      endDate = LocalDate.of(2023, 12, 31);
+    }
 
     Page<Item> items = sellerService.getItems(sellerId, startDate, endDate, minPrice, maxPrice,
         saleStatus, quantityOrder, pageable);
 
     Page<SellerItemResponseDto> itemList = items.map(SellerItemResponseDto::of);
 
-    return new ResponseEntity<>(new SuccessResponse(200, "상품 조회가 완료되었습니다.", itemList), HttpStatus.OK);
+    return new ResponseEntity<>(new SuccessResponse(200, "상품 조회가 완료되었습니다.", itemList),
+        HttpStatus.OK);
+  }
+
+  @GetMapping("/{sellerId}/items/{itemId}")
+  public ResponseEntity<SuccessResponse> getItem(@PathVariable Long sellerId,
+      @PathVariable Long itemId) {
+    ItemDetailDto itemDetail = sellerService.getItem(sellerId, itemId);
+
+    return new ResponseEntity<>(new SuccessResponse(200, "상품 상세 정보 조회가 완료되었습니다.", itemDetail),
+        HttpStatus.OK);
   }
 }

--- a/src/main/java/com/example/ecommerceproject/controller/SellerController.java
+++ b/src/main/java/com/example/ecommerceproject/controller/SellerController.java
@@ -3,6 +3,7 @@ package com.example.ecommerceproject.controller;
 import com.example.ecommerceproject.constant.ItemSellStatus;
 import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
+import com.example.ecommerceproject.domain.dto.ItemUpdateDto;
 import com.example.ecommerceproject.domain.dto.SellerItemResponseDto;
 import com.example.ecommerceproject.domain.dto.response.ApiResponse;
 import com.example.ecommerceproject.domain.dto.response.SuccessResponse;
@@ -23,6 +24,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -91,5 +93,18 @@ public class SellerController {
 
     return new ResponseEntity<>(new SuccessResponse(200, "상품 상세 정보 조회가 완료되었습니다.", itemDetail),
         HttpStatus.OK);
+  }
+
+  @PutMapping("/{sellerId}/items/{itemId}")
+  public ResponseEntity<ApiResponse> editItem(@PathVariable Long sellerId,
+      @PathVariable Long itemId, @Valid ItemUpdateDto itemUpdateDto, BindingResult bindingResult) {
+
+    if (bindingResult.hasErrors()) {
+      ValidUtil.extractErrorMessages(bindingResult);
+    }
+
+    ItemUpdateDto updateDto = sellerService.editItem(sellerId, itemId, itemUpdateDto);
+
+    return new ResponseEntity<>(new SuccessResponse<>(200, "상품 수정이 완료되었습니다.", updateDto), HttpStatus.OK);
   }
 }

--- a/src/main/java/com/example/ecommerceproject/controller/SellerController.java
+++ b/src/main/java/com/example/ecommerceproject/controller/SellerController.java
@@ -74,15 +74,13 @@ public class SellerController {
       startDate = LocalDate.of(1970, 1, 1);
     }
     if (endDate == null) {
-      endDate = LocalDate.of(2023, 12, 31);
+      endDate = LocalDate.now();
     }
 
-    Page<Item> items = sellerService.getItems(sellerId, startDate, endDate, minPrice, maxPrice,
-        saleStatus, quantityOrder, pageable);
+    Page<SellerItemResponseDto> items = sellerService.getItems(sellerId, startDate, endDate,
+        minPrice, maxPrice, saleStatus, quantityOrder, pageable);
 
-    Page<SellerItemResponseDto> itemList = items.map(SellerItemResponseDto::of);
-
-    return new ResponseEntity<>(new SuccessResponse(200, "상품 조회가 완료되었습니다.", itemList),
+    return new ResponseEntity<>(new SuccessResponse(200, "상품 조회가 완료되었습니다.", items),
         HttpStatus.OK);
   }
 
@@ -105,6 +103,7 @@ public class SellerController {
 
     ItemUpdateDto updateDto = sellerService.editItem(sellerId, itemId, itemUpdateDto);
 
-    return new ResponseEntity<>(new SuccessResponse<>(200, "상품 수정이 완료되었습니다.", updateDto), HttpStatus.OK);
+    return new ResponseEntity<>(new SuccessResponse<>(200, "상품 수정이 완료되었습니다.", updateDto),
+        HttpStatus.OK);
   }
 }

--- a/src/main/java/com/example/ecommerceproject/domain/dto/ItemDetailDto.java
+++ b/src/main/java/com/example/ecommerceproject/domain/dto/ItemDetailDto.java
@@ -1,0 +1,34 @@
+package com.example.ecommerceproject.domain.dto;
+
+import com.example.ecommerceproject.constant.Category;
+import com.example.ecommerceproject.constant.ItemSellStatus;
+import com.example.ecommerceproject.domain.model.Item;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ItemDetailDto {
+  // 상품 상세 정보 조회 및 수정에 사용될 dto
+  private String itemName;
+  private int price;
+  private String itemDetail;
+  private ItemSellStatus saleStatus;
+  private Category category;
+
+  public static ItemDetailDto of(Item item){
+    return ItemDetailDto.builder()
+        .itemName(item.getItemName())
+        .price(item.getPrice())
+        .itemDetail(item.getItemDetail())
+        .saleStatus(item.getSaleStatus())
+        .category(item.getCateGory())
+        .build();
+  }
+}

--- a/src/main/java/com/example/ecommerceproject/domain/dto/ItemFormRequestDto.java
+++ b/src/main/java/com/example/ecommerceproject/domain/dto/ItemFormRequestDto.java
@@ -20,9 +20,6 @@ import org.hibernate.validator.constraints.Range;
 @Builder
 public class ItemFormRequestDto {
 
-  // 등록하는 판매자의 식별자
-  private Long sellerId;
-
   @NotBlank(message = "상품명은 필수 입력값입니다.")
   private String itemName;
 

--- a/src/main/java/com/example/ecommerceproject/domain/dto/ItemUpdateDto.java
+++ b/src/main/java/com/example/ecommerceproject/domain/dto/ItemUpdateDto.java
@@ -3,28 +3,40 @@ package com.example.ecommerceproject.domain.dto;
 import com.example.ecommerceproject.constant.Category;
 import com.example.ecommerceproject.constant.ItemSellStatus;
 import com.example.ecommerceproject.domain.model.Item;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Range;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ItemDetailDto {
+public class ItemUpdateDto {
 
-  // 상품 상세 정보 조회에 사용될 dto
+  // 상품 수정에 사용될 dto
+  @NotBlank(message = "상품명은 필수 입력값입니다.")
   private String itemName;
+
+  @NotNull(message = "가격은 필수 입력 값 입니다.")
+  @Range(min = 100, max = 10000000, message = "가격은 백원 이상 천만원 이하여야 합니다.")
   private int price;
+
+  @NotBlank(message = "상품 설명은 필수 입력값입니다.")
   private String itemDetail;
+
+  @NotNull(message = "판매 상태는 필수 입력 값입니다.")
   private ItemSellStatus saleStatus;
+
   private Category category;
 
-  public static ItemDetailDto of(Item item){
-    return ItemDetailDto.builder()
+  public static ItemUpdateDto of(Item item){
+    return ItemUpdateDto.builder()
         .itemName(item.getItemName())
         .price(item.getPrice())
         .itemDetail(item.getItemDetail())

--- a/src/main/java/com/example/ecommerceproject/exception/ErrorCode.java
+++ b/src/main/java/com/example/ecommerceproject/exception/ErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
   SELLER_NOT_FOUND(400, "E0001", "존재하지 않는 판매자입니다."),
-  UNAUTHORIZED_REQUEST(403, "E0002", "권한이 없는 요청입니다.");
+  UNAUTHORIZED_REQUEST(403, "E0002", "권한이 없는 요청입니다."),
+  ITEM_NOT_MATCH(400, "E0003", "해당 판매자가 조회하고자 하는 상품이 존재하지 않습니다.");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/example/ecommerceproject/repository/ItemRepository.java
+++ b/src/main/java/com/example/ecommerceproject/repository/ItemRepository.java
@@ -1,9 +1,10 @@
 package com.example.ecommerceproject.repository;
 
 import com.example.ecommerceproject.domain.model.Item;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface ItemRepository extends JpaRepository<Item, Long>, JpaSpecificationExecutor<Item> {
-
+  Optional<Item> findByIdAndSellerId(long itemId, long sellerId);
 }

--- a/src/main/java/com/example/ecommerceproject/service/SellerService.java
+++ b/src/main/java/com/example/ecommerceproject/service/SellerService.java
@@ -1,6 +1,7 @@
 package com.example.ecommerceproject.service;
 
 import com.example.ecommerceproject.constant.ItemSellStatus;
+import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
 import com.example.ecommerceproject.domain.model.Item;
 import java.time.LocalDate;
@@ -14,5 +15,7 @@ public interface SellerService {
   Page<Item> getItems(Long sellerId, LocalDate startDate, LocalDate endDate,
       int minPrice, int maxPrice, ItemSellStatus itemSellStatus,
       String quantityOrder, Pageable pageable);
+
+  ItemDetailDto getItem(Long sellerId, Long itemId);
 }
 

--- a/src/main/java/com/example/ecommerceproject/service/SellerService.java
+++ b/src/main/java/com/example/ecommerceproject/service/SellerService.java
@@ -4,6 +4,7 @@ import com.example.ecommerceproject.constant.ItemSellStatus;
 import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
 import com.example.ecommerceproject.domain.dto.ItemUpdateDto;
+import com.example.ecommerceproject.domain.dto.SellerItemResponseDto;
 import com.example.ecommerceproject.domain.model.Item;
 import java.time.LocalDate;
 import org.springframework.data.domain.Page;
@@ -13,7 +14,7 @@ public interface SellerService {
 
   String addItem(Long sellerId, ItemFormRequestDto itemFormRequestDto);
 
-  Page<Item> getItems(Long sellerId, LocalDate startDate, LocalDate endDate,
+  Page<SellerItemResponseDto> getItems(Long sellerId, LocalDate startDate, LocalDate endDate,
       int minPrice, int maxPrice, ItemSellStatus itemSellStatus,
       String quantityOrder, Pageable pageable);
 

--- a/src/main/java/com/example/ecommerceproject/service/SellerService.java
+++ b/src/main/java/com/example/ecommerceproject/service/SellerService.java
@@ -3,6 +3,7 @@ package com.example.ecommerceproject.service;
 import com.example.ecommerceproject.constant.ItemSellStatus;
 import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
+import com.example.ecommerceproject.domain.dto.ItemUpdateDto;
 import com.example.ecommerceproject.domain.model.Item;
 import java.time.LocalDate;
 import org.springframework.data.domain.Page;
@@ -17,5 +18,7 @@ public interface SellerService {
       String quantityOrder, Pageable pageable);
 
   ItemDetailDto getItem(Long sellerId, Long itemId);
+
+  ItemUpdateDto editItem(Long sellerId, Long itemId, ItemUpdateDto itemUpdateDto);
 }
 

--- a/src/main/java/com/example/ecommerceproject/service/impl/SellerServiceImpl.java
+++ b/src/main/java/com/example/ecommerceproject/service/impl/SellerServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.ecommerceproject.service.impl;
 
 import com.example.ecommerceproject.constant.ItemSellStatus;
+import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
 import com.example.ecommerceproject.domain.model.Item;
 import com.example.ecommerceproject.domain.model.Member;
@@ -80,5 +81,14 @@ public class SellerServiceImpl implements SellerService {
         .and(ItemSpecification.withQuantityOrder(quantityOrder));
 
     return itemRepository.findAll(spec, pageable);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public ItemDetailDto getItem(Long sellerId, Long itemId) {
+    Item item = itemRepository.findByIdAndSellerId(sellerId, itemId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_MATCH));
+
+    return ItemDetailDto.of(item);
   }
 }

--- a/src/main/java/com/example/ecommerceproject/service/impl/SellerServiceImpl.java
+++ b/src/main/java/com/example/ecommerceproject/service/impl/SellerServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.ecommerceproject.constant.ItemSellStatus;
 import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
 import com.example.ecommerceproject.domain.dto.ItemUpdateDto;
+import com.example.ecommerceproject.domain.dto.SellerItemResponseDto;
 import com.example.ecommerceproject.domain.model.Item;
 import com.example.ecommerceproject.domain.model.Member;
 import com.example.ecommerceproject.domain.model.Stock;
@@ -68,7 +69,7 @@ public class SellerServiceImpl implements SellerService {
   @Override
   // readOnly 사용시, Hibernate와 같은 JPA 구현체는 내부적으로 데이터 변경을 체크하는 작업을 최소화하거나 생략하여 성능 향상
   @Transactional(readOnly = true)
-  public Page<Item> getItems(Long sellerId, LocalDate startDate, LocalDate endDate, int minPrice,
+  public Page<SellerItemResponseDto> getItems(Long sellerId, LocalDate startDate, LocalDate endDate, int minPrice,
       int maxPrice, ItemSellStatus itemSellStatus, String quantityOrder, Pageable pageable) {
 
     LocalDateTime startDateTime = startDate.atStartOfDay();
@@ -81,7 +82,9 @@ public class SellerServiceImpl implements SellerService {
         .and(ItemSpecification.withSaleStatus(itemSellStatus))
         .and(ItemSpecification.withQuantityOrder(quantityOrder));
 
-    return itemRepository.findAll(spec, pageable);
+    Page<Item> items = itemRepository.findAll(spec, pageable);
+
+    return items.map(SellerItemResponseDto::of);
   }
 
   @Override

--- a/src/main/java/com/example/ecommerceproject/service/impl/SellerServiceImpl.java
+++ b/src/main/java/com/example/ecommerceproject/service/impl/SellerServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.ecommerceproject.service.impl;
 import com.example.ecommerceproject.constant.ItemSellStatus;
 import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
+import com.example.ecommerceproject.domain.dto.ItemUpdateDto;
 import com.example.ecommerceproject.domain.model.Item;
 import com.example.ecommerceproject.domain.model.Member;
 import com.example.ecommerceproject.domain.model.Stock;
@@ -90,5 +91,23 @@ public class SellerServiceImpl implements SellerService {
         .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_MATCH));
 
     return ItemDetailDto.of(item);
+  }
+
+  @Override
+  @Transactional
+  public ItemUpdateDto editItem(Long sellerId, Long itemId, ItemUpdateDto itemUpdateDto) {
+    Item item = itemRepository.findByIdAndSellerId(sellerId, itemId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_MATCH));
+
+    item.setItemName(itemUpdateDto.getItemName());
+    item.setPrice(itemUpdateDto.getPrice());
+    item.setItemDetail(itemUpdateDto.getItemDetail());
+    item.setSaleStatus(itemUpdateDto.getSaleStatus());
+    item.setCateGory(itemUpdateDto.getCategory());
+
+    // 변경된 엔티티 저장 (JPA의 역속성 컨텍스트에 의해 자동으로 DB에 반영됩니다)
+    itemRepository.save(item);
+
+    return ItemUpdateDto.of(item);
   }
 }

--- a/src/test/java/com/example/ecommerceproject/service/SellerServiceTest.java
+++ b/src/test/java/com/example/ecommerceproject/service/SellerServiceTest.java
@@ -1,9 +1,11 @@
 package com.example.ecommerceproject.service;
 
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,6 +13,7 @@ import static org.mockito.Mockito.when;
 import com.example.ecommerceproject.constant.Category;
 import com.example.ecommerceproject.constant.ItemSellStatus;
 import com.example.ecommerceproject.constant.Role;
+import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
 import com.example.ecommerceproject.domain.model.Item;
 import com.example.ecommerceproject.domain.model.Member;
@@ -104,5 +107,46 @@ class SellerServiceTest {
 
     // then
     assertEquals(ErrorCode.UNAUTHORIZED_REQUEST, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("판매자의 상품 상세 보기 테스트")
+  void getItemDetail(){
+
+    // Given
+    Item item = Item.builder()
+        .id(1L)
+        .sellerId(1L)
+        .itemName("테스트 네임1")
+        .price(1000)
+        .itemDetail("테스트 상품입니다.")
+        .cateGory(Category.FOOD)
+        .saleStatus(ItemSellStatus.SELL).build();
+
+    when(itemRepository.findByIdAndSellerId(anyLong(), anyLong())).thenReturn(Optional.of(item));
+
+    // When
+    ItemDetailDto itemDetail = sellerService.getItem(1L, 1L);
+
+    // Then
+    assertThat(itemDetail).isNotNull();
+    assertThat(itemDetail.getItemName()).isEqualTo(item.getItemName());
+    assertThat(itemDetail.getPrice()).isEqualTo(item.getPrice());
+    assertThat(itemDetail.getItemDetail()).isEqualTo(item.getItemDetail());
+    assertThat(itemDetail.getSaleStatus()).isEqualTo(item.getSaleStatus());
+    assertThat(itemDetail.getCategory()).isEqualTo(item.getCateGory());
+  }
+
+  @Test
+  @DisplayName("판매자의 상품 상세 보기 실패 테스트")
+  void getItemDetailFailure() {
+    // Given
+    when(itemRepository.findByIdAndSellerId(anyLong(), anyLong())).thenReturn(Optional.empty());
+
+    // When
+    BusinessException exception = assertThrows(BusinessException.class, () -> sellerService.getItem(1L, 1L));
+
+    // Then
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ITEM_NOT_MATCH);
   }
 }

--- a/src/test/java/com/example/ecommerceproject/service/SellerServiceTest.java
+++ b/src/test/java/com/example/ecommerceproject/service/SellerServiceTest.java
@@ -15,6 +15,7 @@ import com.example.ecommerceproject.constant.ItemSellStatus;
 import com.example.ecommerceproject.constant.Role;
 import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
+import com.example.ecommerceproject.domain.dto.ItemUpdateDto;
 import com.example.ecommerceproject.domain.model.Item;
 import com.example.ecommerceproject.domain.model.Member;
 import com.example.ecommerceproject.exception.BusinessException;
@@ -147,5 +148,40 @@ class SellerServiceTest {
 
     // Then
     assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ITEM_NOT_MATCH);
+  }
+
+  @Test
+  @DisplayName("판매자의 상품 수정 테스트")
+  void editItem(){
+    // Given
+    Item item = Item.builder()
+        .id(1L)
+        .sellerId(1L)
+        .itemName("테스트 네임1")
+        .price(1000)
+        .itemDetail("테스트 상품입니다.")
+        .cateGory(Category.FOOD)
+        .saleStatus(ItemSellStatus.SELL).build();
+
+    ItemUpdateDto updateRequest = ItemUpdateDto.builder()
+        .itemName("바꾼 이름1")
+        .price(10001)
+        .itemDetail("바꾼 설명입니다.")
+        .category(Category.BEAUTY)
+        .saleStatus(ItemSellStatus.SELL_STOPPED)
+        .build();
+
+    when(itemRepository.findByIdAndSellerId(anyLong(), anyLong())).thenReturn(Optional.of(item));
+
+    // When
+    ItemUpdateDto itemUpdateDto = sellerService.editItem(1L, 1L, updateRequest);
+
+    // Then
+    assertThat(itemUpdateDto).isNotNull();
+    assertThat(itemUpdateDto.getItemName()).isEqualTo(updateRequest.getItemName());
+    assertThat(itemUpdateDto.getPrice()).isEqualTo(updateRequest.getPrice());
+    assertThat(itemUpdateDto.getItemDetail()).isEqualTo(updateRequest.getItemDetail());
+    assertThat(itemUpdateDto.getSaleStatus()).isEqualTo(updateRequest.getSaleStatus());
+    assertThat(itemUpdateDto.getCategory()).isEqualTo(updateRequest.getCategory());
   }
 }

--- a/src/test/java/com/example/ecommerceproject/service/SellerServiceTest.java
+++ b/src/test/java/com/example/ecommerceproject/service/SellerServiceTest.java
@@ -54,7 +54,6 @@ class SellerServiceTest {
         .build();
 
     ItemFormRequestDto itemFormRequestDto = ItemFormRequestDto.builder()
-        .sellerId(member.getId())
         .itemName("Test Name")
         .price(1000)
         .itemDetail("Test Detail")


### PR DESCRIPTION
### 구현사항

이번 PR에서는 판매자가 특정 상품의 상세 정보를 조회하고, 해당 정보(상품명, 가격, 상품 설명, 판매 상태, 카테고리)를 수정하는 기능을 구현하였습니다. 이에 대해 단위 테스트를 수행하였습니다.

최초 설계에는 상품 상세 조회 시 현재 재고 수량을 표시하고, 판매자가 직접 재고를 수정할 수 있도록 기능을 추가하려 하였습니다. 예를 들어, 현재 재고가 260개 있을 때 판매자가 320개를 추가하려 한다면, 총 580개로 입력할 수 있게 하려 했습니다.

그러나 이렇게 하면 실시간으로 변동하는 재고 수량을 정확하게 반영하지 못하고, 동시성 처리도 필요하게 되어 복잡성이 높아질 수 있습니다. 따라서 이에 대한 기능은 별도로 분리하여 재고 추가 기능으로 따로 구현하려고 합니다.

### 테스트
- [ O] 테스트 코드
- [ O] API 테스트 
