### PR TITLE
Feature/item status management

### DIFF
--- a/src/main/java/com/example/ecommerceproject/EcommerceProjectApplication.java
+++ b/src/main/java/com/example/ecommerceproject/EcommerceProjectApplication.java
@@ -3,9 +3,11 @@ package com.example.ecommerceproject;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class EcommerceProjectApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/ecommerceproject/repository/ItemRepository.java
+++ b/src/main/java/com/example/ecommerceproject/repository/ItemRepository.java
@@ -1,10 +1,15 @@
 package com.example.ecommerceproject.repository;
 
+import com.example.ecommerceproject.constant.ItemSellStatus;
 import com.example.ecommerceproject.domain.model.Item;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface ItemRepository extends JpaRepository<Item, Long>, JpaSpecificationExecutor<Item> {
   Optional<Item> findByIdAndSellerId(long itemId, long sellerId);
+
+  List<Item> findAllBySaleStatusInAndUpdatedAtBefore(List<ItemSellStatus> statuses, LocalDateTime time);
 }

--- a/src/main/java/com/example/ecommerceproject/service/impl/ScheduledService.java
+++ b/src/main/java/com/example/ecommerceproject/service/impl/ScheduledService.java
@@ -1,0 +1,39 @@
+package com.example.ecommerceproject.service.impl;
+
+import com.example.ecommerceproject.constant.ItemSellStatus;
+import com.example.ecommerceproject.domain.model.Item;
+import com.example.ecommerceproject.repository.ItemRepository;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduledService {
+
+  private final ItemRepository itemRepository;
+
+  @Scheduled(cron = "0 0 3 * * ?") // 매일 새벽 3시마다
+  public void deleteItemNotSoldForThreeYears() {
+    List<ItemSellStatus> statuses = Arrays.asList(ItemSellStatus.SOLD_OUT,
+        ItemSellStatus.SELL_STOPPED);
+    LocalDateTime threeYearsAgo = LocalDateTime.now().minusYears(3);
+
+    List<Item> items = itemRepository.findAllBySaleStatusInAndUpdatedAtBefore(
+        statuses, threeYearsAgo);
+
+    // 대량의 데이터를 한번에 삭제하려면 DB에 무리가 갈수 있으므로 나누어 진행
+    int batchSize = 100;
+
+    int totalSize = items.size();
+
+    for(int i = 0; i < totalSize; i += batchSize){
+      int end = Math.min(i + batchSize, totalSize);
+      List<Item> batch = items.subList(i, end);
+      itemRepository.deleteAllInBatch(batch);
+    }
+  }
+}

--- a/src/test/java/com/example/ecommerceproject/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/example/ecommerceproject/repository/ItemRepositoryTest.java
@@ -249,7 +249,7 @@ class ItemRepositoryTest {
 
       // 저장 전에(save(item)) 이 item.setCreatedAt()을 통해 등록일자를 바꾸었을때 save 시 @CreatedDate로 인해
       // 테스트 당시 시간이 설정되었음. 따라서 save를 통해 영속화를 하고, set을 해주었을때 따로 save를 하지 않아도
-      // 더티 체킹으로 인해 등록일짜가 바뀌고.. 우선 되는것 같음...
+      // 더티 체킹으로 인해 등록일짜가 바뀜
       item.setCreatedAt(startDate.plusMonths(i));
     }
 
@@ -258,7 +258,6 @@ class ItemRepositoryTest {
             .and(ItemSpecification.withCreatedDateBetween(startDate, endDate))
     );
 
-    System.out.println(startDate + "는 이때야");
     assertEquals(5, itemList.size());
   }
 

--- a/src/test/java/com/example/ecommerceproject/service/impl/ScheduledServiceTest.java
+++ b/src/test/java/com/example/ecommerceproject/service/impl/ScheduledServiceTest.java
@@ -1,0 +1,68 @@
+package com.example.ecommerceproject.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import com.example.ecommerceproject.domain.model.Item;
+import com.example.ecommerceproject.repository.ItemRepository;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class ScheduledServiceTest {
+
+  @Autowired
+  private ScheduledService scheduledService;
+
+  @Autowired
+  private ItemRepository itemRepository;
+
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
+
+//  @Test
+//  public void deleteOldItems(){
+//    // Given
+//    Item item = Item.builder()
+//        .id(1L)
+//        .sellerId(1L)
+//        .itemName("테스트 네임1")
+//        .price(1000)
+//        .itemDetail("테스트 상품입니다.")
+//        .cateGory(Category.FOOD)
+//        .saleStatus(ItemSellStatus.SOLD_OUT).build();
+//
+//    itemRepository.save(item);
+//    item.setCreatedAt(LocalDateTime.now().minusYears(3).minusDays(1));
+//    item.setUpdatedAt(LocalDateTime.now().minusYears(3).minusDays(1));
+//
+//    // when
+//    scheduledService.deleteItemNotSoldForThreeYears();
+//
+//    // Then
+//    List<Item> items = itemRepository.findAll();
+//    assertThat(items.size()).isEqualTo(0);
+//  }
+
+  @Test
+  public void deleteOldItems(){
+    // Given
+    String sql = "INSERT INTO item (item_id, seller_id, item_name, price, item_detail, cate_gory, sale_status, created_at, updated_at) " +
+        "VALUES (1, 1, '테스트 네임1', 1000, '테스트 상품입니다.', 'FOOD', 'SOLD_OUT', ?, ?)";
+
+    LocalDateTime threeYearsAgo = LocalDateTime.now().minusYears(3).minusDays(1);
+    jdbcTemplate.update(sql, Timestamp.valueOf(threeYearsAgo), Timestamp.valueOf(threeYearsAgo));
+
+    // When
+    scheduledService.deleteItemNotSoldForThreeYears();
+
+    // Then
+    List<Item> items = itemRepository.findAll();
+    assertThat(items.size()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
### 구현 사항
SOLD_OUT이나 SELL_STOPPED 상태이며, 3년 동안 업데이트 되지 않은 상품에 대한 배치 삭제 기능을 구현하였습니다.
JpaRepository의 deleteAllInBatch 메서드를 사용하며, 대량의 데이터를 처리할때 성능 이슈를 방지하기 위해 상품을 작은 배치로 나누어서 삭제하게끔 구현하였습니다.
트래픽이 가장 적을것으로 예상되는 새벽 3시에 작업이 수행되게끔 스케줄링 하였습니다.

### 테스트
- [O] 테스트 코드
- [O] API 테스트 
