### PR TITLE
Feature/buyer cancel order

### DIFF
--- a/src/main/java/com/example/ecommerceproject/controller/BuyerController.java
+++ b/src/main/java/com/example/ecommerceproject/controller/BuyerController.java
@@ -23,8 +23,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -86,5 +88,14 @@ public class BuyerController {
 
     return new ResponseEntity<>(new SuccessResponse<>(200, "주문이 완료되었습니다.", orderResponseDto),
         HttpStatus.OK);
+  }
+
+  @PatchMapping ("/{buyerId}/orders/{orderId}/cancel")
+  public ResponseEntity<ApiResponse> cancelOrder(
+      @PathVariable Long buyerId, @PathVariable Long orderId
+  ){
+    String msg = buyerService.cancelOrder(buyerId, orderId);
+
+    return new ResponseEntity(new ApiResponse(200, msg), HttpStatus.OK);
   }
 }

--- a/src/main/java/com/example/ecommerceproject/domain/model/Order.java
+++ b/src/main/java/com/example/ecommerceproject/domain/model/Order.java
@@ -18,10 +18,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "orders")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,7 +41,7 @@ public class Order extends BaseTimeEntity{
   @Enumerated(EnumType.STRING)
   private OrderStatus orderStatus;
 
-  @OneToMany(cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
+  @OneToMany(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
   @JoinColumn(name = "order_id")
   private List<OrderItem> orderItems;
 }

--- a/src/main/java/com/example/ecommerceproject/exception/ErrorCode.java
+++ b/src/main/java/com/example/ecommerceproject/exception/ErrorCode.java
@@ -23,8 +23,10 @@ public enum ErrorCode {
   OUT_OF_STOCK_ITEM_INCLUDED(400,"E0012","주문을 하기 위한 해당 상품의 재고가 부족합니다."),
   BUYER_BALANCE_NOT_FOUND(500, "E0013", "해당 사용자의 잔액 정보가 조회되지 않습니다."),
 
-  INSUFFICIENT_BALANCE(400, "E00014", "주문을 진행하기에 계좌 잔고가 부족합니다.");
-
+  INSUFFICIENT_BALANCE(400, "E0014", "주문을 진행하기에 계좌 잔고가 부족합니다."),
+  ORDER_NOT_FOUND(400, "E0015", "존재하지 않는 주문 정보입니다."),
+  ORDER_ALREADY_CANCELED(400, "E0016", "이미 취소된 주문 입니다."),
+  SELLER_REVENUE_NOT_FOUND(500, "E0017", "판매자의 수익 계좌가 존재하지 않습니다.");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/example/ecommerceproject/service/BuyerService.java
+++ b/src/main/java/com/example/ecommerceproject/service/BuyerService.java
@@ -18,4 +18,6 @@ public interface BuyerService {
       String priceOrder, ItemSellStatus itemSellStatus, Category category, Pageable pageable);
 
   OrderResponseDto orderItems(Long buyerId, OrderRequestDto orderRequestDto);
+
+  String cancelOrder(Long buyerId, Long orderId);
 }

--- a/src/test/java/com/example/ecommerceproject/service/impl/BuyerServiceTest.java
+++ b/src/test/java/com/example/ecommerceproject/service/impl/BuyerServiceTest.java
@@ -1,18 +1,35 @@
 package com.example.ecommerceproject.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.example.ecommerceproject.constant.OrderStatus;
 import com.example.ecommerceproject.constant.Role;
 import com.example.ecommerceproject.domain.dto.MemberInfoDto;
 import com.example.ecommerceproject.domain.model.BuyerBalance;
+import com.example.ecommerceproject.domain.model.Item;
 import com.example.ecommerceproject.domain.model.Member;
+import com.example.ecommerceproject.domain.model.Order;
+import com.example.ecommerceproject.domain.model.OrderItem;
+import com.example.ecommerceproject.domain.model.SellerRevenue;
+import com.example.ecommerceproject.domain.model.Stock;
+import com.example.ecommerceproject.exception.BusinessException;
+import com.example.ecommerceproject.exception.ErrorCode;
 import com.example.ecommerceproject.repository.BuyerBalanceRepository;
+import com.example.ecommerceproject.repository.ItemRepository;
 import com.example.ecommerceproject.repository.MemberRepository;
+import com.example.ecommerceproject.repository.OrderRepository;
+import com.example.ecommerceproject.repository.SellerRevenueRepository;
+import com.example.ecommerceproject.repository.StockRepository;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,13 +47,26 @@ class BuyerServiceTest {
   @Mock
   private BuyerBalanceRepository buyerBalanceRepository;
 
+  @Mock
+  private OrderRepository orderRepository;
+
+  @Mock
+  private StockRepository stockRepository;
+
+  @Mock
+  private SellerRevenueRepository sellerRevenueRepository;
+
+  @Mock
+  private ItemRepository itemRepository;
+
   @InjectMocks
   private BuyerServiceImpl buyerService;
 
-  @Test
-  void chargeBalance(){
-    // given
-    Member member = Member.builder()
+  private Member member;
+  private BuyerBalance buyerBalance;
+  @BeforeEach
+  void setUp(){
+    member = Member.builder()
         .id(1L)
         .name("test")
         .email("test@example.com")
@@ -46,10 +76,15 @@ class BuyerServiceTest {
         .role(Role.BUYER)
         .build();
 
-    BuyerBalance buyerBalance = BuyerBalance.builder()
+    buyerBalance = BuyerBalance.builder()
         .memberId(1L)
         .balance(0L).build();
+  }
 
+  @Test
+  @DisplayName("잔액 충전 테스트")
+  void chargeBalance(){
+    // given
     when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
     when(buyerBalanceRepository.findByMemberId(anyLong())).thenReturn(Optional.of(buyerBalance));
 
@@ -60,5 +95,90 @@ class BuyerServiceTest {
     assertEquals(10000L, infoDto.getBalance());
     verify(memberRepository, times(1)).findById(1L);
     verify(buyerBalanceRepository, times(1)).findByMemberId(1L);
+  }
+
+  @Test
+  @DisplayName("이미 취소된 주문에 대해 취소 요청을 할 시 에러 발생")
+  void cancelOrder_WithCanceledOrder(){
+    // Given
+    Order order = Order.builder()
+        .id(1L)
+        .buyerId(1L)
+        .orderStatus(OrderStatus.CANCELED)
+        .build();
+
+    when(memberRepository.findById(anyLong()))
+        .thenReturn(Optional.of(member));
+
+    when(orderRepository.findById(anyLong()))
+        .thenReturn(Optional.of(order));
+
+    // When
+    BusinessException exception = assertThrows(BusinessException.class, () -> {
+      buyerService.cancelOrder(1L, 1L);
+    });
+
+    // Then
+    assertEquals(ErrorCode.ORDER_ALREADY_CANCELED, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("주문 상태가 정상일 때, 주문 취소 요청이 정상 적으로 처리됨")
+  void cancelOrder_WithValidOrder(){
+    // Given
+    Order order = Order.builder()
+        .id(1L)
+        .buyerId(1L)
+        .totalPrice(1000L)
+        .orderStatus(OrderStatus.COMPLETED)
+        .build();
+
+    List<OrderItem> orderItems = new ArrayList<>();
+    OrderItem orderItem = OrderItem.builder()
+        .itemId(1L)
+        .quantity(1)
+        .price(1000)
+        .build();
+    orderItems.add(orderItem);
+    order.setOrderItems(orderItems);
+
+    Stock stock = Stock.builder()
+        .id(1L)
+        .quantity(5)
+        .build();
+
+    Item item = Item.builder()
+        .id(1L)
+        .sellerId(2L)
+        .stock(stock)
+        .build();
+
+    Member member = Member.builder()
+        .id(1L)
+        .build();
+
+    SellerRevenue sellerRevenue = SellerRevenue.builder()
+        .revenue(1000L)
+        .build();
+
+    when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+
+    when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
+
+    when(itemRepository.findById(anyLong())).thenReturn(Optional.of(item));
+
+    when(stockRepository.findByIdForUpdate(anyLong())).thenReturn(Optional.of(stock));
+
+    when(sellerRevenueRepository.findByMemberId(anyLong())).thenReturn(Optional.of(sellerRevenue));
+
+    when(buyerBalanceRepository.findByMemberId(anyLong())).thenReturn(Optional.of(buyerBalance));
+
+    String result = buyerService.cancelOrder(1L, 1L);
+
+    // Then
+    assertEquals("주문 취소가 완료되었습니다 :)", result);
+    assertEquals(6, stock.getQuantity());
+    assertEquals(1000, buyerBalance.getBalance());
+    assertEquals(0, sellerRevenue.getRevenue());
   }
 }


### PR DESCRIPTION
### 구현 사항

주문 취소 로직을 구현하였으며, 다음과 같은 순서로 동작합니다.

1. 주문 상태 검증 : validateOrderStatus 메서드를 통해 이미 취소된 주문인지 확인합니다.
2. 주문 상품 정보 조회 : 주문에 포함된 상품 목록을 order.getOrderItems()를 통해 조회합니다.
3. 재고 반환 : addStocks 메서드를 통해 주문된 상품들의 재고를 반환합니다. 여기에서 재고에 락을 설정하여 동시 변경을 제어합니다.
4. 판매자 수익 차감 : decreaseSellerRevenue 메서드를 통해 판매자들의 수익을 차감합니다.
5. 구매자 잔고 반환 : increaseBuyerBalance 메서드를 통해 구매자에게 상품 금액을 반환합니다. 이때 구매자 계좌에 락을 설정하여 동시 변경을 제어합니다.
6. 주문 상태 업데이트 : 주문 상태를 OrderStatus.CANCELED로 업데이트합니다.
7. 응답 반환 : 취소 처리 완료 메세지를 반환합니다.

### 테스트
[O] 테스트 코드
[O] API 테스트 
