### PR TITLE
Feature/seller withdraw revenue

### DIFF
--- a/src/main/java/com/example/ecommerceproject/controller/SellerController.java
+++ b/src/main/java/com/example/ecommerceproject/controller/SellerController.java
@@ -5,6 +5,8 @@ import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
 import com.example.ecommerceproject.domain.dto.ItemUpdateDto;
 import com.example.ecommerceproject.domain.dto.SellerItemResponseDto;
+import com.example.ecommerceproject.domain.dto.WithdrawDto;
+import com.example.ecommerceproject.domain.dto.WithdrawResponseDto;
 import com.example.ecommerceproject.domain.dto.response.ApiResponse;
 import com.example.ecommerceproject.domain.dto.response.SuccessResponse;
 import com.example.ecommerceproject.service.SellerService;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -109,11 +112,25 @@ public class SellerController {
   // PUT을 사용할수도 있지만 이 경우엔 멱등성을 가지지 않기에 POST가 어울린다고 판단.
   @PostMapping("/{sellerId}/items/{itemId}/stock")
   public ResponseEntity<SuccessResponse> addItemStock(@PathVariable Long sellerId,
-      @PathVariable Long itemId, int addNum){
+      @PathVariable Long itemId, int addNum) {
 
     SellerItemResponseDto item = sellerService.addStock(sellerId, itemId, addNum);
 
-    return new ResponseEntity<>(new SuccessResponse(200, "재고 추가가 완료되었습니다.",item),
+    return new ResponseEntity<>(new SuccessResponse(200, "재고 추가가 완료되었습니다.", item),
         HttpStatus.OK);
+  }
+
+  @PostMapping("/{sellerId}/balance/withdraw")
+  public ResponseEntity<SuccessResponse> withdraw(@PathVariable Long sellerId,
+      @Valid @RequestBody WithdrawDto withdrawDto, BindingResult bindingResult) {
+
+    if (bindingResult.hasErrors()) {
+      ValidUtil.extractErrorMessages(bindingResult);
+    }
+
+    WithdrawResponseDto responseDto = sellerService.withdrawBalance(sellerId, withdrawDto);
+
+    return new ResponseEntity(new SuccessResponse(200, "출금이 완료되었습니다. "
+        + "남은 잔고는 다음과 같습니다.", responseDto), HttpStatus.OK);
   }
 }

--- a/src/main/java/com/example/ecommerceproject/domain/dto/WithdrawDto.java
+++ b/src/main/java/com/example/ecommerceproject/domain/dto/WithdrawDto.java
@@ -1,0 +1,19 @@
+package com.example.ecommerceproject.domain.dto;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WithdrawDto {
+
+  @NotNull(message = "출금할 금액을 입력해주세요!")
+  @Min(value = 1000, message = "출금할 금액을 최소 천원 이상 입력해주세요.")
+  private Long amount; // 출금할 금액
+}

--- a/src/main/java/com/example/ecommerceproject/domain/dto/WithdrawResponseDto.java
+++ b/src/main/java/com/example/ecommerceproject/domain/dto/WithdrawResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.ecommerceproject.domain.dto;
+
+import com.example.ecommerceproject.domain.model.SellerRevenue;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WithdrawResponseDto {
+
+  private Long balance;
+
+  public static WithdrawResponseDto of(Long balance){
+    return WithdrawResponseDto.builder()
+        .balance(balance)
+        .build();
+  }
+}

--- a/src/main/java/com/example/ecommerceproject/exception/ErrorCode.java
+++ b/src/main/java/com/example/ecommerceproject/exception/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
   INSUFFICIENT_BALANCE(400, "E0014", "주문을 진행하기에 계좌 잔고가 부족합니다."),
   ORDER_NOT_FOUND(400, "E0015", "존재하지 않는 주문 정보입니다."),
   ORDER_ALREADY_CANCELED(400, "E0016", "이미 취소된 주문 입니다."),
-  SELLER_REVENUE_NOT_FOUND(500, "E0017", "판매자의 수익 계좌가 존재하지 않습니다.");
+  SELLER_REVENUE_NOT_FOUND(500, "E0017", "판매자의 수익 계좌가 존재하지 않습니다."),
+  INSUFFICIENT_REVENUE(400, "E0018", "출금하려는 금액보다 판매자 분의 수익이 적습니다.");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/example/ecommerceproject/service/SellerService.java
+++ b/src/main/java/com/example/ecommerceproject/service/SellerService.java
@@ -5,6 +5,8 @@ import com.example.ecommerceproject.domain.dto.ItemDetailDto;
 import com.example.ecommerceproject.domain.dto.ItemFormRequestDto;
 import com.example.ecommerceproject.domain.dto.ItemUpdateDto;
 import com.example.ecommerceproject.domain.dto.SellerItemResponseDto;
+import com.example.ecommerceproject.domain.dto.WithdrawDto;
+import com.example.ecommerceproject.domain.dto.WithdrawResponseDto;
 import com.example.ecommerceproject.domain.model.Item;
 import java.time.LocalDate;
 import org.springframework.data.domain.Page;
@@ -23,5 +25,7 @@ public interface SellerService {
   ItemUpdateDto editItem(Long sellerId, Long itemId, ItemUpdateDto itemUpdateDto);
 
   SellerItemResponseDto addStock(Long sellerId, Long itemId, int addNum);
+
+  WithdrawResponseDto withdrawBalance(Long sellerId, WithdrawDto withdrawDto);
 }
 


### PR DESCRIPTION
### 구현사항
판매자가 본인의 수익을 출금하는 기능을 구현하였습니다.

출금 금액이 판매자의 수익보다 클 경우에 대비해 예외 처리를 하였습니다.
락을 사용하여(findByMemberId()), 출금 작업 중 동일한 SellerRevenue에 대한 동시 트랜잭션 접근을 방지하였습니다.

### 테스트
- [O] 테스트 코드
- [O] API 테스트 
